### PR TITLE
BDC-13 Ensure Cloudfront Distribution Gets Tagged

### DIFF
--- a/deploy/bdc-online.template.yml
+++ b/deploy/bdc-online.template.yml
@@ -19,7 +19,7 @@ Resources:
               - HEAD
             AllowedOrigins:
               - "https://brekkedancecenter.com"
-  
+
   BucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -46,7 +46,6 @@ Resources:
   CloudfrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
-      Tags: []
       DistributionConfig:
         Aliases:
           - !Ref DomainName


### PR DESCRIPTION
This will ensure that the cloudfront distribution receives the same tags as from its containing stack