### PR TITLE
BDC-13 Manually Add Cloudfront Tags

### DIFF
--- a/deploy/bdc-online.template.yml
+++ b/deploy/bdc-online.template.yml
@@ -46,6 +46,17 @@ Resources:
   CloudfrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
+      Tags:
+        - Key: Name
+          Value: Brekke Dance Center Online
+        - Key: Owner
+          Value: Cythral
+        - Key: OwnerContact
+          Value: Talen Fisher
+        - Key: Customer
+          Value: Brekke Dance Center
+        - Key: CustomerContact
+          Value: Paula Brekke
       DistributionConfig:
         Aliases:
           - !Ref DomainName


### PR DESCRIPTION
Manually add the appropriate tags to Cloudfront, since CloudFormation does not seem to be adding these for us.